### PR TITLE
Add Services / Embed section with WeTransform

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,8 +523,12 @@ puts csv_string
 ### Rust
 
 - csv - [(Doc)](https://docs.rs/csv)
- 
 
+
+### Services / Embed
+
+- WeTransform - [(Doc)](https://www.wetransform.com), [(npm)](https://www.npmjs.com/package/@wetransform/core) - Embeddable AI file importer. Drop-in modal or iframe for B2B SaaS, customers upload CSV (or Excel, PDF, XML, JSON), the AI maps columns to your schema and validates, you receive clean data via API or webhook.
+  
 
 ## Conferences
 


### PR DESCRIPTION
The current "Libraries & Tools" section covers parsing libraries by language. Embeddable services and SaaS-side tools that process CSV at the application boundary aren't covered. Adding a new sub-section "Services / Embed" and seeding it with WeTransform, an embeddable AI file importer that drops into B2B SaaS products to handle CSV uploads from end customers (with column mapping, validation, and webhook delivery).

Happy to rename the section or move the entry if you have a preferred taxonomy.