### PR TITLE
PYTHON: add e-commerce SKU profit analyzer

### DIFF
--- a/SERVICES.md
+++ b/SERVICES.md
@@ -43,6 +43,8 @@ puts csv_string
 
 - csvkit - [(Source)](https://github.com/wireservice/csvkit), [(Doc)](http://csvkit.readthedocs.org)
 
+- E-commerce SKU Profit Analyzer - [(Source)](https://github.com/zhailong8845-art/china-ecom-profit-analyzer) - zero-dependency CLI that converts Chinese e-commerce order CSV exports into per-SKU net-profit, margin, and loss-warning reports; runs offline and outputs Excel-friendly CSV plus JSON
+
 - Panda read_csv - [(Doc)](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_csv.html)
 
 
@@ -77,5 +79,4 @@ puts csv_string
 - Excel to Markdown - [(Link)](https://exceltomd.com/csv-to-markdown) - free browser-local converter that turns CSV files into Markdown tables. No signup or server upload; it also provides header and column-alignment controls before copy or download.
 
 - CSV / JSON / XML Converter - [(Link)](https://nutilz.com/csv-json-xml-converter) - free tool that converts between CSV, JSON, and XML in any direction. No signup; files are processed in memory and discarded immediately, never stored or logged.
-
 


### PR DESCRIPTION
## Summary

Add one Python CLI entry for an offline e-commerce CSV profit analyzer. It calculates per-SKU net profit and margin after refunds, platform fees, shipping, and goods cost, then produces Excel-friendly CSV and JSON loss-warning reports.

## Verification

- Source link returns HTTP 200.
- Entry appears once in `SERVICES.md`.
- `git diff --check` passes.
- The linked project contains source, five passing tests, sample input/output, and a versioned release.

No pricing or promotional link is included in the list entry.