### PR TITLE
SERVICES: add CSV Preflight browser-local validator

### DIFF
--- a/SERVICES.md
+++ b/SERVICES.md
@@ -78,4 +78,5 @@ puts csv_string
 
 - CSV / JSON / XML Converter - [(Link)](https://nutilz.com/csv-json-xml-converter) - free tool that converts between CSV, JSON, and XML in any direction. No signup; files are processed in memory and discarded immediately, never stored or logged.
 
+- CSV Preflight - [(Link)](https://softpeanut.github.io/csv-preflight/) - free browser-local CSV validator and normalizer. Checks headers, row widths, duplicate rows, delimiters, and common encoding failures with no signup or file upload.
 


### PR DESCRIPTION
## Summary

Add CSV Preflight to **Services / Embed**. It is a free browser-local CSV validator and normalizer that requires no signup and does not upload files.

The entry follows the format of the recently merged browser-local service additions.